### PR TITLE
fix: preserve batch on flush failure in flushOversize (data loss)

### DIFF
--- a/quickwit.go
+++ b/quickwit.go
@@ -265,7 +265,9 @@ func (c *Client) loop() {
 		}
 
 		if len(buffer) <= batchSize {
-			flush(buffer)
+			if !flush(buffer) {
+				return false
+			}
 			buffer = buffer[:0]
 			return true
 		}


### PR DESCRIPTION
## Problem

In `flushOversize`, the non-oversize branch ignored the result of `flush`:

```go
if len(buffer) <= batchSize {
    flush(buffer)        // return value ignored
    buffer = buffer[:0]  // buffer cleared even on failure
    return true          // always reports success
}
```

The normal flush path appends one item at a time and flushes when `len(buffer) == batchSize`, so it always takes this branch. As a result:

- A failed flush (server 5xx, network error, timeout) silently **drops the batch**.
- `flushOversize` returns `true`, so `retryFlush` believes the flush succeeded and **never retries** — the retry-until-success logic is effectively dead on the common path.

## Fix

Propagate the failure so the buffer is preserved and retried:

```go
if len(buffer) <= batchSize {
    if !flush(buffer) {
        return false
    }
    buffer = buffer[:0]
    return true
}
```

## Test plan
- [ ] `go build ./...` / `go vet ./...`
- [ ] Manual: point client at an endpoint returning 500 and confirm the batch is retried rather than dropped, and is delivered once the endpoint recovers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8xCiTt4kx5YahHEsbc8pM)_