### PR TITLE
fix: increment WaitGroup before starting loop goroutines

### DIFF
--- a/quickwit.go
+++ b/quickwit.go
@@ -170,13 +170,14 @@ func (c *Client) setup() {
 	}
 	c.ingestBuffer = make(chan any, c.ingestBufferSize)
 
-	for range c.getConcurrent() {
+	concurrent := c.getConcurrent()
+	c.stopWg.Add(concurrent)
+	for range concurrent {
 		go c.loop()
 	}
 }
 
 func (c *Client) loop() {
-	c.stopWg.Add(1)
 	defer c.stopWg.Done()
 
 	var buf bytes.Buffer


### PR DESCRIPTION
## Problem

`stopWg.Add(1)` was called *inside* the `loop()` goroutine:

```go
for range c.getConcurrent() {
    go c.loop()
}
...
func (c *Client) loop() {
    c.stopWg.Add(1)        // runs inside the goroutine
    defer c.stopWg.Done()
```

`Close()` calls `stopWg.Wait()`. If `Close()` runs before the goroutines reach `Add(1)` — exactly the `Ingest(); Close()` sequence in the existing test — `Wait()` observes a zero counter and returns immediately, so buffered data is never flushed. This violates the `sync.WaitGroup` contract: *"calls with a positive delta that start when the counter is zero must happen before a Wait."*

## Fix

Increment the counter in `setup()` before launching the goroutines:

```go
concurrent := c.getConcurrent()
c.stopWg.Add(concurrent)
for range concurrent {
    go c.loop()
}
```

`loop()` keeps only `defer c.stopWg.Done()`.

## Test plan
- [ ] `go build ./...`, `go test ./...`
- [ ] `go test -race` on a test that ingests then immediately closes

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8xCiTt4kx5YahHEsbc8pM)_