### PR TITLE
fix: omit zero-valued search options instead of sending them

### DIFF
--- a/quickwit.go
+++ b/quickwit.go
@@ -408,14 +408,24 @@ func (c *Client) Search(ctx context.Context, query string, opt *SearchOpt) (*Sea
 		Format: Ptr("json"),
 	}
 	if opt != nil {
-		params.StartTimestamp = &opt.StartTimestamp
-		params.EndTimestamp = &opt.EndTimestamp
-		params.StartOffset = &opt.StartOffset
-		params.MaxHits = &opt.MaxHits
+		if opt.StartTimestamp != 0 {
+			params.StartTimestamp = &opt.StartTimestamp
+		}
+		if opt.EndTimestamp != 0 {
+			params.EndTimestamp = &opt.EndTimestamp
+		}
+		if opt.StartOffset != 0 {
+			params.StartOffset = &opt.StartOffset
+		}
+		if opt.MaxHits != 0 {
+			params.MaxHits = &opt.MaxHits
+		}
 		params.SearchField = opt.SearchField
 		params.SnippetFields = opt.SnippetFields
 		params.SortBy = opt.SortBy
-		params.Format = &opt.Format
+		if opt.Format != "" {
+			params.Format = &opt.Format
+		}
 	}
 
 	reqBody, err := json.Marshal(params)


### PR DESCRIPTION
## Problem

`searchRequestQueryString` uses `*int64`/`*string` + `omitempty` so optional params can be omitted, but `Search` unconditionally took the address of every field:

```go
params.EndTimestamp = &opt.EndTimestamp   // non-nil even when 0
params.Format       = &opt.Format         // overwrites the "json" default with ""
```

`omitempty` does not omit a non-nil pointer to a zero value, so the `omitempty` had no effect. Consequences for a caller passing e.g. `&SearchOpt{MaxHits: 10}`:

- `end_timestamp: 0` is sent → Quickwit matches nothing before the epoch (empty result set).
- `start_timestamp: 0` / `start_offset: 0` sent unnecessarily.
- `format: ""` clobbers the `"json"` default set just above.

## Fix

Only assign each optional field when it is non-zero, and only override the format default when `Format` is set:

```go
if opt.EndTimestamp != 0 { params.EndTimestamp = &opt.EndTimestamp }
...
if opt.Format != "" { params.Format = &opt.Format }
```

## Test plan
- [ ] `go build ./...`
- [ ] Marshal `searchRequestQueryString` for `&SearchOpt{MaxHits: 10}` and confirm `end_timestamp`/`start_timestamp`/`start_offset` are absent and `format` is `"json"`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8xCiTt4kx5YahHEsbc8pM)_