### PR TITLE
fix: make Close() safe before setup and idempotent

### DIFF
--- a/quickwit.go
+++ b/quickwit.go
@@ -39,6 +39,7 @@ type Client struct {
 	concurrent          int
 	ingestBuffer        chan any
 	onceSetup           sync.Once
+	onceClose           sync.Once
 	stopWg              sync.WaitGroup
 	closeSignal         chan struct{}
 	onDiscard           OnDiscardFunc
@@ -159,8 +160,11 @@ func (c *Client) Ingest(data ...any) {
 }
 
 func (c *Client) Close() {
-	close(c.closeSignal)
-	close(c.ingestBuffer)
+	c.onceSetup.Do(c.setup)
+	c.onceClose.Do(func() {
+		close(c.closeSignal)
+		close(c.ingestBuffer)
+	})
 	c.stopWg.Wait()
 }
 

--- a/quickwit.go
+++ b/quickwit.go
@@ -11,7 +11,6 @@ import (
 	"slices"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 )
 
@@ -41,7 +40,6 @@ type Client struct {
 	ingestBuffer        chan any
 	onceSetup           sync.Once
 	onceClose           sync.Once
-	setupDone           atomic.Bool
 	stopWg              sync.WaitGroup
 	closeSignal         chan struct{}
 	onDiscard           OnDiscardFunc
@@ -162,9 +160,7 @@ func (c *Client) Ingest(data ...any) {
 }
 
 func (c *Client) Close() {
-	if !c.setupDone.Load() {
-		return
-	}
+	c.onceSetup.Do(c.setup)
 	c.onceClose.Do(func() {
 		close(c.closeSignal)
 		close(c.ingestBuffer)
@@ -181,8 +177,6 @@ func (c *Client) setup() {
 	for range c.getConcurrent() {
 		go c.loop()
 	}
-
-	c.setupDone.Store(true)
 }
 
 func (c *Client) loop() {

--- a/quickwit.go
+++ b/quickwit.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -40,6 +41,7 @@ type Client struct {
 	ingestBuffer        chan any
 	onceSetup           sync.Once
 	onceClose           sync.Once
+	setupDone           atomic.Bool
 	stopWg              sync.WaitGroup
 	closeSignal         chan struct{}
 	onDiscard           OnDiscardFunc
@@ -160,7 +162,9 @@ func (c *Client) Ingest(data ...any) {
 }
 
 func (c *Client) Close() {
-	c.onceSetup.Do(c.setup)
+	if !c.setupDone.Load() {
+		return
+	}
 	c.onceClose.Do(func() {
 		close(c.closeSignal)
 		close(c.ingestBuffer)
@@ -177,6 +181,8 @@ func (c *Client) setup() {
 	for range c.getConcurrent() {
 		go c.loop()
 	}
+
+	c.setupDone.Store(true)
 }
 
 func (c *Client) loop() {


### PR DESCRIPTION
## Problem

```go
func (c *Client) Close() {
    close(c.closeSignal)
    close(c.ingestBuffer)   // panics if nil; panics if already closed
    c.stopWg.Wait()
}
```

`ingestBuffer` is created lazily in `setup()` (run from `Ingest`). So:

- Calling `Close()` before any `Ingest()` panics with **"close of nil channel"**.
- Calling `Close()` twice panics with **"close of closed channel"**.

## Fix

Ensure setup has run so the channel exists, and guard the closes with a `sync.Once` so `Close()` is idempotent:

```go
func (c *Client) Close() {
    c.onceSetup.Do(c.setup)
    c.onceClose.Do(func() {
        close(c.closeSignal)
        close(c.ingestBuffer)
    })
    c.stopWg.Wait()
}
```

## Notes / out of scope
This does **not** address `Ingest` racing with `Close` (a concurrent send on the channel being closed) — that needs send-side synchronization and is left for a separate change.

## Test plan
- [ ] `go build ./...`, `go test ./...`
- [ ] `NewClient(...).Close()` with no prior `Ingest` does not panic
- [ ] Calling `Close()` twice does not panic

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8xCiTt4kx5YahHEsbc8pM)_