### PR TITLE
fix: remove duplicate newline between NDJSON records

### DIFF
--- a/quickwit.go
+++ b/quickwit.go
@@ -199,7 +199,6 @@ func (c *Client) loop() {
 
 		for _, x := range buffer {
 			jsonEnc.Encode(x)
-			buf.WriteString("\n")
 		}
 
 		ctx := context.Background()


### PR DESCRIPTION
## Problem

```go
for _, x := range buffer {
    jsonEnc.Encode(x)
    buf.WriteString("\n")   // extra newline
}
```

`json.Encoder.Encode` *"writes the JSON encoding of v to the stream, followed by a newline character."* The additional `buf.WriteString("\n")` therefore inserts a blank line between every record, producing `{...}\n\n{...}\n\n`. Quickwit usually tolerates blank lines, but the framing is incorrect and wastes bytes.

## Fix

Drop the redundant `buf.WriteString("\n")`.

## Test plan
- [ ] `go build ./...`
- [ ] Inspect the request body for a 2-record batch and confirm exactly one `\n` separates records.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8xCiTt4kx5YahHEsbc8pM)_