### PR TITLE
fix: handle JSON encode errors during flush

### DIFF
--- a/quickwit.go
+++ b/quickwit.go
@@ -199,7 +199,11 @@ func (c *Client) loop() {
 		buf.Reset()
 
 		for _, x := range buffer {
-			jsonEnc.Encode(x)
+			if err := jsonEnc.Encode(x); err != nil {
+				slog.Error("quickwit: failed to encode record, discarding", "error", err)
+				c.invokeOnDiscard(x)
+				continue
+			}
 		}
 
 		ctx := context.Background()


### PR DESCRIPTION
## Problem

```go
for _, x := range buffer {
    jsonEnc.Encode(x)        // error ignored
    buf.WriteString("\n")
}
```

If a record can't be marshalled (e.g. an unsupported type, a `MarshalJSON` that errors), `Encode` returns an error and writes nothing — but the code ignored it and still appended a `\n`, producing a stray blank line and silently losing the record with no signal to the caller.

## Fix

Detect the error, report it through the existing discard callback, and skip the record cleanly (the `continue` also avoids the orphaned newline):

```go
if err := jsonEnc.Encode(x); err != nil {
    slog.Error("quickwit: failed to encode record, discarding", "error", err)
    c.invokeOnDiscard(x)
    continue
}
buf.WriteString("\n")
```

A permanently un-encodable record is dropped rather than wedging the retry loop forever.

## Notes
This branches off `main`, so it still contains the duplicate-newline (#8). The two will reconcile on merge.

## Test plan
- [ ] `go build ./...`
- [ ] Ingest a value that fails to marshal (e.g. a channel) and confirm it triggers `OnDiscard` and does not corrupt the batch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8xCiTt4kx5YahHEsbc8pM)_