### PR TITLE
fix: preserve record order in oversize buffer flush

### DIFF
--- a/quickwit.go
+++ b/quickwit.go
@@ -270,10 +270,9 @@ func (c *Client) loop() {
 			return true
 		}
 
-		parts := slices.Collect(slices.Chunk(buffer, batchSize))
 		var processed int
 
-		for _, chunk := range parts {
+		for chunk := range slices.Chunk(buffer, batchSize) {
 			if !flush(chunk) {
 				break
 			}
@@ -281,8 +280,11 @@ func (c *Client) loop() {
 		}
 
 		// drop the flushed prefix, keeping unprocessed records in their
-		// original order at the front of the buffer
+		// original order at the front of the buffer, and clear the now
+		// unused tail so flushed records can be garbage collected
+		oldLen := len(buffer)
 		remaining := copy(buffer, buffer[processed:])
+		clear(buffer[remaining:oldLen])
 		buffer = buffer[:remaining]
 		return len(buffer) == 0
 	}

--- a/quickwit.go
+++ b/quickwit.go
@@ -271,7 +271,6 @@ func (c *Client) loop() {
 		}
 
 		parts := slices.Collect(slices.Chunk(buffer, batchSize))
-		slices.Reverse(parts)
 		var processed int
 
 		for _, chunk := range parts {
@@ -281,7 +280,10 @@ func (c *Client) loop() {
 			processed += len(chunk)
 		}
 
-		buffer = buffer[:len(buffer)-processed]
+		// drop the flushed prefix, keeping unprocessed records in their
+		// original order at the front of the buffer
+		remaining := copy(buffer, buffer[processed:])
+		buffer = buffer[:remaining]
 		return len(buffer) == 0
 	}
 


### PR DESCRIPTION
## Problem

```go
parts := slices.Collect(slices.Chunk(buffer, batchSize))
slices.Reverse(parts)        // <-- sends chunks tail-first
...
buffer = buffer[:len(buffer)-processed]
```

When the buffer exceeds `batchSize` (after an auto batch-size reduction), `flushOversize` reverses the chunks so that the processed records form a contiguous suffix it can drop with `buffer[:len-processed]`. The side effect is that records are sent to Quickwit in **reverse chunk order**, scrambling ingestion order.

## Fix

Flush chunks in their original order and drop the *flushed prefix* by shifting the remaining records to the front:

```go
parts := slices.Collect(slices.Chunk(buffer, batchSize))
var processed int
for _, chunk := range parts {
    if !flush(chunk) {
        break
    }
    processed += len(chunk)
}
remaining := copy(buffer, buffer[processed:])
buffer = buffer[:remaining]
```

`copy` uses memmove semantics so the overlapping shift is safe, and anchoring the slice at index 0 avoids retaining the already-flushed elements. Partial-failure behavior is preserved: on the first failing chunk we stop, and everything from that chunk onward stays buffered for retry — now in correct order.

## Test plan
- [ ] `go build ./...`, `go vet ./...`
- [ ] Unit test: buffer of N records, small batchSize, fail the 2nd chunk; assert the first chunk is delivered in order and the remainder is retained in order.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8xCiTt4kx5YahHEsbc8pM)_