### PR TITLE
fix: make context cancel unconditional in flush

### DIFF
--- a/quickwit.go
+++ b/quickwit.go
@@ -211,11 +211,11 @@ func (c *Client) loop() {
 		}
 
 		ctx := context.Background()
+		cancel := context.CancelFunc(func() {})
 		if t := c.getIngestTimeout(); t != 0 {
-			var cancel context.CancelFunc
 			ctx, cancel = context.WithTimeout(ctx, t)
-			defer cancel()
 		}
+		defer cancel()
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(buf.Bytes()))
 		if err != nil {
 			return false


### PR DESCRIPTION
## Summary

- The context `cancel` function in `flush` was declared inside a conditional `if` block and deferred there. While functionally correct, a `defer` inside a conditional is subtle: if the closure were later refactored to use named returns, the cancellation point would silently shift.
- Fixed by initializing `cancel` to a no-op function before the conditional, then deferring it unconditionally. The `defer cancel()` line is now always present at the top of the HTTP section, making the lifetime of the context cancel unambiguous.

## Test plan

- [ ] `go test ./...` passes (no behavioral change, so no new tests needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)